### PR TITLE
Fixing bug with creating relations to draft pages

### DIFF
--- a/index.php
+++ b/index.php
@@ -27,7 +27,7 @@ Kirby::plugin('jonasholfeld/many-to-many-field', [
                 if (relationIsChanged($newPage, $oldPage, $relation)) {
 
                     // Getting Content type and page from the blueprint of the updated page
-                    $relatedPage = page($newPage->blueprint()->field($relation)['relatedPage']);
+                    $relatedPage = kirby()->page($newPage->blueprint()->field($relation)['relatedPage']);
                     $relationField = $newPage->blueprint()->field($relation)['relatationField'];
                     
                     // Getting the autoid value of the updated page
@@ -99,7 +99,7 @@ Kirby::plugin('jonasholfeld/many-to-many-field', [
                 $primaryKey = $page->AUTOID();
 
                 // Getting related page and relation field from the blueprint of the deleted page
-                $relatedPage = page($page->blueprint()->field($relation)['relatedPage']);
+                $relatedPage = kirby()->page($page->blueprint()->field($relation)['relatedPage']);
                 $relationField = $page->blueprint()->field($relation)['relatationField'];
 
                 foreach ($foreignKeys as $foreignKey) {
@@ -195,9 +195,9 @@ function addRelation($page, $value, $relationField)
 {
     // Getting relations field from page to add to
     try {
-        $fieldData = YAML::decode(page($page)->$relationField()->value());
+        $fieldData = YAML::decode(kirby()->page($page)->$relationField()->value());
     } catch (Throwable $e) {
-        throw new Exception('Many to Many Field Plugin: related page or relatation field is faulty or missing. '.$e->getMessage());
+        throw new Exception('Many to Many Field Plugin: related page or relatation field is faulty or missing. ' .$e->getMessage());
     }
 
     // Getting Length of relations field before insert
@@ -215,7 +215,7 @@ function addRelation($page, $value, $relationField)
     // If fieldLengthAfter is same as fieldLengthBefore, nothing was added so we skip updating to avoid cascading
     if ($fieldLengthBefore !== $fieldLengthAfter) {
         try {
-            page($page)->update([$relationField => YAML::encode($fieldData)]);
+            kirby()->page($page)->update([$relationField => YAML::encode($fieldData)]);
 
             return true;
         } catch (Exception $e) {


### PR DESCRIPTION
When I attempt to create a relation to a draft page, I get this error:

<img width="529" alt="Screenshot 2022-03-09 at 12 02 35" src="https://user-images.githubusercontent.com/111979/157438386-336931ec-0607-4bc9-b4a3-d404f46183b2.png">

The problem seems to be the use of `page()` in `index.php`, which will only return published pages according to the docs:

_"The page() helper fetches published pages only. To fetch a draft, you have to use $kirby->page('somepage')."_
Source: https://getkirby.com/docs/reference/templates/helpers/page

The solution seems to be to replace all instances of `page()` with `kirby()->page()`. 